### PR TITLE
Make install.sh work with other shells and add an uninstall script.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,32 @@
 #!/bin/bash
-echo "info: Installling plymouth-preview"
+
+echo "[Info]: Installling plymouth-preview"
+mkdir -p $HOME/.local/bin/
 install plymouth-preview $HOME/.local/bin/plymouth-preview
-grep -qxF 'PATH="$HOME/.local/bin:${PATH}"' $HOME/.bashrc || echo 'PATH="$HOME/.local/bin:${PATH}"' >> $HOME/.bashrc
-grep -qxF 'export PATH' $HOME/.bashrc || echo 'export PATH' >> $HOME/.bashrc
-echo "info: The next step might ask you to introduce your password to create symbolic link"
+
+if [[ $SHELL = *"bash" ]]; then
+	RCPATH=$HOME/.bashrc
+elif [[ $SHELL = *"zsh" ]]; then
+	RCPATH=$HOME/.zshrc
+elif [[ $SHELL = *"fish" ]]; then
+	RCPATH=None
+	fish -c fish_add_path $HOME/.local/bin/
+else
+	echo "[Warning]: Shell is not supported. Please search up a tutorial online on how to add to PATH for your specific shell.
+	The installation is finished, you just have to have ~/.local/bin/ in your PATH."
+	exit 1
+fi
+if [[ $RCPATH != "None" ]]; then
+	grep -qxF 'PATH="$HOME/.local/bin:${PATH}"' $RCPATH || echo 'PATH="$HOME/.local/bin:${PATH}"' >> $RCPATH
+	grep -qxF 'export PATH' $HOME/.bashrc || echo 'export PATH' >> $RCPATH
+	
+	echo "[Info]: Added path '~/.local/bin/' to your .bashrc"
+fi
+
+echo "[Info]: The next step might ask for your password to create a symbolic link."
 sudo ln -sf $HOME/.local/bin/plymouth-preview /usr/local/bin
-source ~/.bashrc
-echo "info: Success. Sourced '~/.bashrc'"
+
+if [[ $SHELL = *"bash" ]]; then source ~/.bashrc
+elif [[ $SHELL = *"zsh" ]]; then source ~/.zshrc
+fi
+echo "[Info]: Successfully installed, enjoy!"

--- a/plymouth-preview
+++ b/plymouth-preview
@@ -7,7 +7,7 @@
 
 chk_root () {
   if [ ! $( id -u ) -eq 0 ]; then
-    echo Must be run as root
+    echo "The installer must be run as root (sudo)."
     exit
   fi
 }

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,11 @@ sudo apt install plymouth-x11
 
 # Install
 
-The install script will make the ~/.local/bin/ directory if it doesn't exist already, put the plymouth-preview script there and adds it to PATH in .bashrc, just in case it ain't already added to PATH in your system. It will also add a symlink in /usr/local/bin to make the plymouth-preview script work properly when ran as root. If you have a different dedicated scripts directory already added to PATH, just copy the plymouth-preview script there and create the necesary symlink
+The install script will make the ~/.local/bin/ directory if it doesn't exist already, put the plymouth-preview script there and adds it to PATH in .bashrc, just in case it ain't already added to PATH in your system. It will also add a symlink in /usr/local/bin to make the plymouth-preview script work properly when ran as root. If you have a different dedicated scripts directory already added to your PATH, just copy the plymouth-preview script there and create the necesary symlink.
+
+# Uninstall
+
+The uninstall script will remove the symlinks '~/.local/bin/plymouth-preview' and '/usr/local/bin/plymouth-preview'. Everything else the install script did (like creating ~/.local/bin/ and adding it to PATH), just in case you will install other stuff in there, but you can remove those manually.
 
 ```
 git clone https://github.com/eylles/plymouth-preview

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # plymouth-preview
 
-This script was originally found in [khAttAm's site](https://khattam.info/plymouth-preview-a-tool-to-preview-your-plymouth-theme-2010-11-19.html) but it wasn't up at the time i decided to upload it here, also made a small modification as khAttAm's original script provides a 5s preview of the plymouth theme by default, i personally find 10s to be a more useful time frame. The plymouth-preview script must be run as root, if you don't run it like so the script will return an error message reminding you to do so, also you can specify the amount of time it will run by typing the time in seconds as an argument when you run it. 
+This script was originally found on [khAttAm's site](https://khattam.info/plymouth-preview-a-tool-to-preview-your-plymouth-theme-2010-11-19.html) but it wasn't up at the time i decided to upload it here, also made a small modification as khAttAm's original script provides a 5s preview of the plymouth theme by default, i personally find 10s to be a more useful time frame. The plymouth-preview script must be run as root, if you don't run it like so the script will return an error message reminding you to do so, also you can specify the amount of time it will run by typing the time in seconds as an argument when you run it. 
 For example to preview your plymouth theme for 20 seconds just run
 
 ```
@@ -15,7 +15,7 @@ sudo apt install plymouth-x11
 
 # Install
 
-The install script will locate the plymouth preview script in the $HOME/.local/bin/ directory and adds it to PATH in .bashrc just in case it ain't already added to PATH in your system, the installation script also adds a symlink in /usr/local/bin to allow for proper work of the plymouth-preview script when ran as root. If you have a different dedicated scripts directory already added to PATH just copy the plymouth-preview script there and create the necesary symlink
+The install script will make the ~/.local/bin/ directory if it doesn't exist already, put the plymouth-preview script there and adds it to PATH in .bashrc, just in case it ain't already added to PATH in your system. It will also add a symlink in /usr/local/bin to make the plymouth-preview script work properly when ran as root. If you have a different dedicated scripts directory already added to PATH, just copy the plymouth-preview script there and create the necesary symlink
 
 ```
 git clone https://github.com/eylles/plymouth-preview

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,5 @@
+echo "Uninstalling plymouth-preview..."
+rm $HOME/.local/bin/plymouth-preview
+echo "Uninstalling the next step might require your password to remove the symlink in '/usr/local/bin/'"
+sudo rm /usr/local/bin/plymouth-preview
+echo "Plymouth-preview uninstalled successfully!"


### PR DESCRIPTION
Also updated text to make it more understandable, and edited the README accordingly to match the modifications. Oh, and there was also a bug that I fixed. On a clean install, `~/.local/bin/` doesn't exist, and the script couldn't copy the stuff it needed, so I made it create one if didn't exist using `mkdir -p`.
I tested this on an Ubuntu 23.10 virtual machine just to make sure everything works well on a clean install.